### PR TITLE
Added changes to search (incl. new screen), types, and constants

### DIFF
--- a/app/(root)/search/_layout.tsx
+++ b/app/(root)/search/_layout.tsx
@@ -1,0 +1,23 @@
+import { Stack } from "expo-router";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+
+function UniqueURLLayout() {
+  return (
+    <SafeAreaProvider>
+      {/* ... other code */}
+      <Stack>
+        {/* ... other stack screens */}
+        <Stack.Screen
+          name="index" // Note the change here
+          options={{ headerShown: false, gestureEnabled: true }}
+        />
+        <Stack.Screen
+          name="bikeSearch" // Note the change here
+          options={{ headerShown: false, gestureEnabled: true }}
+        />
+      </Stack>
+    </SafeAreaProvider>
+  );
+}
+
+export default UniqueURLLayout;

--- a/app/(root)/search/bikeSearch.tsx
+++ b/app/(root)/search/bikeSearch.tsx
@@ -1,0 +1,715 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  View,
+  Text,
+  Button,
+  FlatList,
+  TouchableOpacity,
+  TextInput,
+  TouchableWithoutFeedback,
+  ScrollView,
+  Keyboard,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { FontAwesome5 } from "@expo/vector-icons";
+import { AntDesign } from "@expo/vector-icons";
+import { Entypo } from "@expo/vector-icons";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { FontAwesome } from "@expo/vector-icons";
+
+import { useAuth } from "../../../context";
+import SearchItem from "../../components/searchItem";
+import {
+  CategoryType,
+  Listing,
+  UserContextType,
+  BikeCategoryType,
+  BikeBrandType,
+  BikeGender,
+} from "../../../types";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  CATEGORIES,
+  BIKE_CATEGORIES,
+  BIKE_BRANDS,
+  BIKE_GENDER,
+} from "../../../constants";
+import { router } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+
+/* Search Result Screen */
+export default function Search() {
+  const { listings } = useAuth() as UserContextType;
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [filteredResults, setFilteredResults] = useState<Listing[] | null>(
+    listings ? Object.values(listings) : null
+  );
+
+  // map
+  const categoryIcons = {
+    electronics: "electronics-picture",
+    clothing: "clothing-picture",
+    food: "food-picture",
+  };
+
+  const safeAreaInsets = useSafeAreaInsets();
+  const [sortByDropdownVisible, setSortByDropdownVisible] =
+    useState<boolean>(false);
+
+  // State for category dropdown
+  const [categoryDropdownVisible, setCategoryDropdownVisible] =
+    useState<boolean>(false);
+
+  const [isInputFocused, setInputFocused] = useState<boolean>(false);
+
+  // for bike categories
+  const [selectedBikeCategories, setSelectedBikeCategories] = useState<
+    string[]
+  >(BIKE_CATEGORIES.map((category) => category.value));
+
+  // for brand categories
+  const [selectedBrandCategories, setSelectedBrandCategories] = useState<
+    string[]
+  >(BIKE_BRANDS.map((category) => category.value));
+
+  // for gender categories
+  const [selectedGenderCategories, setSelectedGenderCategories] = useState<
+    string[]
+  >(BIKE_GENDER.map((category) => category.value));
+
+  // Function to toggle selection of categories
+  const toggleBikeCategorySelection = useCallback(
+    (category: string) => {
+      if (selectedBikeCategories.includes(category)) {
+        setSelectedBikeCategories(
+          selectedBikeCategories.filter((c) => c !== category)
+        );
+      } else {
+        setSelectedBikeCategories([...selectedBikeCategories, category]);
+      }
+    },
+    [selectedBikeCategories]
+  );
+
+  // Function to toggle selection of categories
+  const toggleBrandCategorySelection = useCallback(
+    (category: string) => {
+      if (selectedBrandCategories.includes(category)) {
+        setSelectedBrandCategories(
+          selectedBrandCategories.filter((c) => c !== category)
+        );
+      } else {
+        setSelectedBrandCategories([...selectedBrandCategories, category]);
+      }
+    },
+    [selectedBrandCategories]
+  );
+
+  // Function to toggle selection of Gender Categories
+  const toggleGenderCategorySelection = useCallback(
+    (category: string) => {
+      if (selectedGenderCategories.includes(category)) {
+        setSelectedGenderCategories(
+          selectedGenderCategories.filter((c) => c !== category)
+        );
+      } else {
+        setSelectedGenderCategories([...selectedGenderCategories, category]);
+      }
+    },
+    [selectedGenderCategories]
+  );
+
+  // Function to toggle all categories selection
+  const toggleBikeAllCategories = useCallback(() => {
+    if (selectedBikeCategories.length === BIKE_CATEGORIES.length) {
+      // If all categories are currently selected, deselect all
+      setSelectedBikeCategories([]);
+    } else {
+      // If not all categories are selected, select all
+      setSelectedBikeCategories(
+        BIKE_CATEGORIES.map((category) => category.value)
+      );
+    }
+  }, [selectedBikeCategories]);
+
+  // Function to toggle all categories selection
+  const toggleBrandAllCategories = useCallback(() => {
+    if (selectedBrandCategories.length === BIKE_BRANDS.length) {
+      // If all categories are currently selected, deselect all
+      setSelectedBrandCategories([]);
+    } else {
+      // If not all categories are selected, select all
+      setSelectedBrandCategories(BIKE_BRANDS.map((category) => category.value));
+    }
+  }, [selectedBrandCategories]);
+
+  // Function to toggle all categories selection
+  const toggleGenderAllCategories = useCallback(() => {
+    if (selectedGenderCategories.length === BIKE_GENDER.length) {
+      // If all categories are currently selected, deselect all
+      setSelectedGenderCategories([]);
+    } else {
+      // If not all categories are selected, select all
+      setSelectedGenderCategories(
+        BIKE_GENDER.map((category) => category.value)
+      );
+    }
+  }, [selectedGenderCategories]);
+
+  useEffect(() => {
+    const delayDebounce = setTimeout(() => {
+      if (searchQuery && listings) {
+        const results = Object.values(listings).filter((listing) =>
+          listing.title.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+        // Filter by selected categories if any categories are selected
+        if (selectedBikeCategories.length > 0) {
+          // if there is search query
+          if (searchQuery) {
+            // Edit: Search filters by (1) title, (2) keywords, and (3) user selected categories
+            const filteredByCategoryAndSearch = Object.values(listings).filter(
+              (listing) =>
+                // (1) search by title
+                (listing.title
+                  .toLowerCase()
+                  .includes(searchQuery.toLowerCase()) ||
+                  // (2) search by keywords
+                  (listing.keywords !== null &&
+                    listing.keywords?.some((keyword) =>
+                      keyword.toLowerCase().includes(searchQuery.toLowerCase())
+                    ))) &&
+                // (3) filter by user's selected categories
+                selectedBikeCategories.some((category) =>
+                  listing.categories.includes(category)
+                )
+            );
+            // set the filtered results
+            setFilteredResults(filteredByCategoryAndSearch);
+          } else {
+            // no search query
+            const filteredByCategory = results.filter((listing) =>
+              selectedBikeCategories.some((category) =>
+                listing.categories.includes(category)
+              )
+            );
+            setFilteredResults(filteredByCategory);
+          }
+        } else {
+          // display nothing when user de-selected all categories
+          setFilteredResults([]);
+        }
+      } else {
+        // If there's no search query, apply category filter if any categories are selected
+        if (selectedBikeCategories.length > 0 && listings) {
+          const filteredByCategory = Object.values(listings).filter((listing) =>
+            selectedBikeCategories.some((category) =>
+              listing.categories.includes(category)
+            )
+          );
+          setFilteredResults(filteredByCategory);
+        } else {
+          // display nothing
+          setFilteredResults([]);
+        }
+      }
+    }, 500); // 500 ms delay
+
+    return () => clearTimeout(delayDebounce);
+    // }, [searchQuery, listings]);
+  }, [searchQuery, listings, selectedBikeCategories]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: Listing }) => <SearchItem item={item} />,
+    []
+  );
+
+  // methods for sorting (for drop down menus)
+  const sortByRecentlyAdded = useCallback(() => {
+    const sortedResults = [...(filteredResults ?? [])].sort(
+      (a, b) => b.datePosted - a.datePosted
+    );
+    setFilteredResults(sortedResults);
+    setSortByDropdownVisible(false); // Close the dropdown after sorting
+  }, [filteredResults]);
+
+  const sortByPriceDescending = useCallback(() => {
+    const sortedResults = [...(filteredResults ?? [])].sort(
+      (a, b) => b.price - a.price
+    );
+    setFilteredResults(sortedResults);
+    setSortByDropdownVisible(false); // Close the dropdown after sorting
+  }, [filteredResults]);
+
+  const sortByPriceAscending = useCallback(() => {
+    const sortedResults = [...(filteredResults ?? [])].sort(
+      (a, b) => a.price - b.price
+    );
+    setFilteredResults(sortedResults);
+    setSortByDropdownVisible(false); // Close the dropdown after sorting
+  }, [filteredResults]);
+
+  const resetSort = useCallback(() => {
+    // Restore original search results without affecting the current filtering
+    const results = Object.values(listings).filter((listing) =>
+      listing.title.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+    setFilteredResults(results);
+    setSortByDropdownVisible(false); // Close the dropdown after resetting
+  }, [listings, searchQuery]);
+
+  return (
+    // dropdown menu dissapears if user touches anywhere else on the screen
+    <ScrollView showsVerticalScrollIndicator={false}>
+      <TouchableOpacity
+        style={{
+          position: "absolute",
+          top: safeAreaInsets.top + 10, // Adjust for safe area
+          left: 10,
+          zIndex: 10, // Ensure it's above other elements
+        }}
+        onPress={() => router.back()}
+      >
+        <Ionicons name="chevron-back-outline" size={40} color="#38B39C" />
+      </TouchableOpacity>
+
+      <TouchableWithoutFeedback
+        onPress={() => {
+          setSortByDropdownVisible(false);
+          setCategoryDropdownVisible(false);
+          setInputFocused(false);
+          Keyboard.dismiss();
+        }}
+      >
+        <View
+          style={{
+            flex: 1,
+            marginTop: safeAreaInsets.top + 60,
+            paddingHorizontal: 20,
+          }}
+        >
+          <Text style={{ fontWeight: "bold", fontSize: 30 }}>
+            Bikes & Accessories{" "}
+          </Text>
+
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              alignContent: "center",
+              marginTop: 10,
+            }}
+          >
+            <TextInput
+              style={{
+                flex: 1,
+                height: 45,
+                // borderColor: "black",
+                paddingHorizontal: 10,
+                backgroundColor: "#E6E6E6",
+                shadowColor: "black",
+                shadowOffset: { width: 1, height: 4 }, // Shadow offset
+                shadowOpacity: 0.2, // Shadow opacity
+                shadowRadius: 5, // Shadow radius
+                elevation: 2, // Elevation for Android
+                borderRadius: 30,
+                // borderWidth: 1,
+              }}
+              placeholder="Search Bike Brand, Name, Type..."
+              value={searchQuery} // input value
+              onChangeText={(text) => setSearchQuery(text)}
+              onFocus={() => setInputFocused(true)} // Set focus state to true
+              onBlur={() => setInputFocused(false)} // Set focus state to false
+            />
+            <TouchableOpacity
+              onPress={() => Keyboard.dismiss()}
+              style={{
+                position: "absolute", // Position the button absolutely
+                right: 10, // Adjust the right spacing as needed
+                zIndex: 1, // Ensure the button is above other content
+              }}
+            >
+              <MaterialIcons name="search" size={24} color="black" />
+            </TouchableOpacity>
+          </View>
+
+          {/* (1) For Bike Categories */}
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
+              paddingHorizontal: 0,
+              marginBottom: 5,
+              marginTop: 15,
+            }}
+          >
+            <Text style={{ fontWeight: "bold", fontSize: 20 }}>
+              Filter by Bike Types
+            </Text>
+            <TouchableOpacity
+              style={{
+                marginBottom: 5,
+                marginTop: 10,
+              }}
+              onPress={toggleBikeAllCategories}
+            >
+              <Text
+                style={{
+                  fontWeight: "bold",
+                  fontSize: 16,
+                  marginRight: 10,
+                  textAlign: "center",
+                }}
+              >
+                {selectedBikeCategories.length === BIKE_CATEGORIES.length
+                  ? "Deselect All"
+                  : "Select All"}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {!isInputFocused && searchQuery.length == 0 && (
+            <View
+              style={{
+                justifyContent: "center",
+                alignItems: "center",
+                padding: 5,
+                paddingVertical: 0,
+              }}
+            >
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                }}
+              >
+                {BIKE_CATEGORIES.map((category) => (
+                  <TouchableOpacity
+                    key={category.value}
+                    style={{
+                      paddingRight: 10,
+                      paddingLeft: 10,
+                      paddingBottom: 10,
+                      paddingTop: 5,
+                      marginTop: 0,
+                      marginBottom: 10,
+                      marginHorizontal: 5,
+                      borderRadius: 10,
+                      justifyContent: "center",
+                      alignItems: "center",
+                      backgroundColor: selectedBikeCategories.includes(
+                        category.value
+                      )
+                        ? "#E6E6E6"
+                        : "transparent",
+                    }}
+                    onPress={() => toggleBikeCategorySelection(category.value)}
+                  >
+                    <Text
+                      style={{
+                        textAlign: "center",
+                        fontSize: 18,
+                        // fontWeight: "bold",
+                        marginTop: 5,
+                      }}
+                    >
+                      {category.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            </View>
+          )}
+
+          {/* (2) For Brand Categories */}
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
+              paddingHorizontal: 0,
+              marginBottom: 5,
+              marginTop: 0,
+            }}
+          >
+            <Text style={{ fontWeight: "bold", fontSize: 20 }}>
+              Filter by Brands
+            </Text>
+            <TouchableOpacity
+              style={{
+                marginBottom: 5,
+                marginTop: 10,
+              }}
+              onPress={toggleBrandAllCategories}
+            >
+              <Text
+                style={{
+                  fontWeight: "bold",
+                  fontSize: 16,
+                  marginRight: 10,
+                  textAlign: "center",
+                }}
+              >
+                {selectedBrandCategories.length === BIKE_BRANDS.length
+                  ? "Deselect All"
+                  : "Select All"}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {!isInputFocused && searchQuery.length == 0 && (
+            <View
+              style={{
+                justifyContent: "center",
+                alignItems: "center",
+                padding: 5,
+                paddingVertical: 0,
+              }}
+            >
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                }}
+              >
+                {BIKE_BRANDS.map((category) => (
+                  <TouchableOpacity
+                    key={category.value}
+                    style={{
+                      paddingRight: 10,
+                      paddingLeft: 10,
+                      paddingBottom: 10,
+                      paddingTop: 5,
+                      marginTop: 0,
+                      marginBottom: 10,
+                      marginHorizontal: 5,
+                      borderRadius: 10,
+                      justifyContent: "center",
+                      alignItems: "center",
+                      backgroundColor: selectedBrandCategories.includes(
+                        category.value
+                      )
+                        ? "#E6E6E6"
+                        : "transparent",
+                    }}
+                    onPress={() => toggleBrandCategorySelection(category.value)}
+                  >
+                    <Text
+                      style={{
+                        textAlign: "center",
+                        fontSize: 18,
+                        // fontWeight: "bold",
+                        marginTop: 5,
+                      }}
+                    >
+                      {category.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            </View>
+          )}
+
+          {/* (3) For Brand Categories */}
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
+              paddingHorizontal: 0,
+              marginBottom: 5,
+              marginTop: 0,
+            }}
+          >
+            <Text style={{ fontWeight: "bold", fontSize: 20 }}>
+              Filter by Gender
+            </Text>
+            <TouchableOpacity
+              style={{
+                marginBottom: 5,
+                marginTop: 10,
+              }}
+              onPress={toggleGenderAllCategories}
+            >
+              <Text
+                style={{
+                  fontWeight: "bold",
+                  fontSize: 16,
+                  marginRight: 10,
+                  textAlign: "center",
+                }}
+              >
+                {selectedGenderCategories.length === BIKE_GENDER.length
+                  ? "Deselect All"
+                  : "Select All"}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {!isInputFocused && searchQuery.length == 0 && (
+            <View
+              style={{
+                justifyContent: "center",
+                alignItems: "center",
+                padding: 5,
+                paddingVertical: 0,
+              }}
+            >
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                }}
+              >
+                {BIKE_GENDER.map((category) => (
+                  <TouchableOpacity
+                    key={category.value}
+                    style={{
+                      paddingRight: 10,
+                      paddingLeft: 10,
+                      paddingBottom: 10,
+                      paddingTop: 5,
+                      marginTop: 0,
+                      marginBottom: 10,
+                      marginHorizontal: 5,
+                      borderRadius: 10,
+                      justifyContent: "center",
+                      alignItems: "center",
+                      backgroundColor: selectedGenderCategories.includes(
+                        category.value
+                      )
+                        ? "#E6E6E6"
+                        : "transparent",
+                    }}
+                    onPress={() =>
+                      toggleGenderCategorySelection(category.value)
+                    }
+                  >
+                    <Text
+                      style={{
+                        textAlign: "center",
+                        fontSize: 18,
+                        // fontWeight: "bold",
+                        marginTop: 5,
+                      }}
+                    >
+                      {category.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            </View>
+          )}
+
+          <Text style={{ fontWeight: "bold", fontSize: 20, paddingBottom: 10 }}>
+            Sort by
+          </Text>
+
+          <ScrollView
+            horizontal
+            scrollEnabled={true}
+            contentContainerStyle={{
+              paddingHorizontal: 5,
+              flexGrow: 1,
+              marginTop: !isInputFocused && !searchQuery.length ? 0 : 15, // edited the logic to resolve overlaps with search tab
+            }}
+            showsHorizontalScrollIndicator={false}
+          >
+            <TouchableOpacity
+              onPress={sortByRecentlyAdded}
+              style={{
+                padding: 10,
+                borderRadius: 25,
+                backgroundColor: "#E6E6E6",
+                marginRight: 10,
+                alignItems: "center",
+                flexDirection: "row",
+              }}
+            >
+              <Text style={{ textAlign: "center", fontSize: 17 }}>Recent </Text>
+              <MaterialIcons name="access-time" size={24} color="#38B39C" />
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              onPress={sortByPriceDescending}
+              style={{
+                padding: 10,
+                borderRadius: 25,
+                backgroundColor: "#E6E6E6",
+                marginRight: 10,
+                alignItems: "center",
+                flexDirection: "row",
+              }}
+            >
+              <Text style={{ textAlign: "center", fontSize: 17 }}>
+                Price Descending{" "}
+              </Text>
+              <MaterialCommunityIcons
+                name="order-numeric-descending"
+                size={24}
+                color="#38B39C"
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={sortByPriceAscending}
+              style={{
+                padding: 10,
+                borderRadius: 25,
+                backgroundColor: "#E6E6E6",
+                alignItems: "center",
+                flexDirection: "row",
+              }}
+            >
+              <Text style={{ textAlign: "center", fontSize: 17 }}>
+                Price Ascending{" "}
+              </Text>
+              <MaterialCommunityIcons
+                name="order-numeric-ascending"
+                size={24}
+                color="#38B39C"
+              />
+            </TouchableOpacity>
+          </ScrollView>
+          <View>
+            <Text
+              style={{
+                fontWeight: "bold",
+                fontSize: 25,
+                marginTop: 20,
+              }}
+            >
+              Search Results
+            </Text>
+          </View>
+
+          <FlatList
+            data={filteredResults}
+            initialNumToRender={7}
+            scrollEnabled={false}
+            renderItem={renderItem}
+            keyExtractor={(item) => item.listingId}
+          />
+          {isInputFocused && (
+            <View
+              style={{
+                position: "absolute",
+                top: 90,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: "auto",
+                zIndex: 1, // Make sure it covers other components
+              }}
+            />
+          )}
+        </View>
+      </TouchableWithoutFeedback>
+    </ScrollView>
+  );
+}

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,9 @@
-import { CategoryType } from "./types";
+import {
+  CategoryType,
+  BikeCategoryType,
+  BikeBrandType,
+  BikeGender,
+} from "./types";
 
 export const CATEGORIES: readonly { label: string; value: CategoryType }[] = [
   { label: "Electronics", value: CategoryType.ELECTRONICS },
@@ -18,3 +23,41 @@ export const CATEGORIES: readonly { label: string; value: CategoryType }[] = [
   { label: "Sporting Goods", value: CategoryType.SPORTING_GOODS },
   { label: "Toys & Games", value: CategoryType.TOYS_GAMES },
 ] as const;
+
+export const BIKE_CATEGORIES: readonly {
+  label: string;
+  value: BikeCategoryType;
+}[] = [
+  { label: "Road", value: BikeCategoryType.ROAD },
+  { label: "Sport", value: BikeCategoryType.SPORT },
+  { label: "Electric", value: BikeCategoryType.ELECTRIC },
+  { label: "Commuter/Urban", value: BikeCategoryType.COMMUTER_URBAN },
+  { label: "Comfort", value: BikeCategoryType.COMFORT },
+  { label: "Fitness", value: BikeCategoryType.FITNESS },
+  { label: "Hybrid", value: BikeCategoryType.HYBRID },
+];
+
+export const BIKE_BRANDS: readonly {
+  label: string;
+  value: BikeBrandType;
+}[] = [
+  { label: "KHS", value: BikeBrandType.KHS },
+  { label: "Fuji", value: BikeBrandType.FUJI },
+  { label: "Velotric", value: BikeBrandType.VELOTRIC },
+  { label: "Jamis", value: BikeBrandType.JAMIS },
+  { label: "Norco", value: BikeBrandType.NORCO },
+  { label: "Biria", value: BikeBrandType.BIRIA },
+  { label: "EVO", value: BikeBrandType.EVO },
+  { label: "Serfas", value: BikeBrandType.SERFAS },
+  { label: "Others", value: BikeBrandType.OTHERS },
+];
+
+export const BIKE_GENDER: readonly {
+  label: string;
+  value: BikeGender;
+}[] = [
+  { label: "Unisex", value: BikeGender.UNISEX },
+  { label: "Men's", value: BikeGender.MENS },
+  { label: "Women's", value: BikeGender.WOMENS },
+  { label: "Not Designated", value: BikeGender.NOT_DESIGNATED },
+];

--- a/types.ts
+++ b/types.ts
@@ -84,3 +84,35 @@ export type Offer = {
   dateActionTaken?: Date;
   accepted: boolean | null;
 };
+
+// Bike categories
+export enum BikeCategoryType {
+  ROAD = "ROAD",
+  SPORT = "SPRT",
+  COMMUTER_URBAN = "COMU",
+  COMFORT = "COMF",
+  FITNESS = "FITN",
+  HYBRID = "HYBR",
+  ELECTRIC = "ELEC",
+}
+
+// Bike Brands
+export enum BikeBrandType {
+  KHS = "KHS",
+  FUJI = "FUJI",
+  VELOTRIC = "VELO",
+  JAMIS = "JAMI",
+  NORCO = "NOR",
+  BIRIA = "BIRI",
+  EVO = "EVO",
+  SERFAS = "SER",
+  OTHERS = "OTHER",
+}
+
+// Gender
+export enum BikeGender {
+  UNISEX = "UNI",
+  MENS = "MEN",
+  WOMENS = "WOM",
+  NOT_DESIGNATED = "ND",
+}


### PR DESCRIPTION
(1) New Screen for Bike Search: No listing nor bike specific search capability yet (as I cannot implement unless we have new posting screen updates). Can filter by bike types, brands, gender (for now), and can sort as with last screen. 

(2) Added selectall / deselect all 

(3) Added stemmers to handle cases such as: finding the listing 'perfume' when typing 'perfumes' or 'calvin klein' when typing 'calvin kleins'. Modified search such that if there isn't a direct match/simple match between the search query and the listing title/keywords, it splits the queries into tokens and evaluate if there are any matches between the tokenized query and the listing (with the condition that each tokenized query compared are at least 3 characters long, to prevent situation such as search query of 'Apple o' to show all listings that includes the character 'o').

(4) Made additions to types.tsx and constants.tsx to add BIKE specific types/constants 

(5) Deleted the original search.tsx file. Made new directory '/search' under (root) and added _layout.tsx, index.tsx, and bikeSearch.tsx